### PR TITLE
Reducing memory footprint, removing duplicate titles from stocks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,4 +13,3 @@ General TODO statements based on known issues and general feedback.
 1. [q] Random taxonomies in results (like Disney in the /auto taxonomy), should taxonomies be used?
   * [a] Check the taxonomies relevance in the output.
 1. Allow only the newest (`yyyymmdd>20170619`)
-1. Lower memory size and check that building still is OK.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-memory: 500MB
+memory: 256MB
 instances: 1
 declared-services:
   discovery:


### PR DESCRIPTION
The duplicate titles in stocks come about due to the multiple different URLs provided for the same finance content.