### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-discovery-news-alerting.svg?branch=master)](https://travis-ci.org/IBM/watson-discovery-news-alerting)
-![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/538ed648bda50b9f22d64a8be817840f/badge.svg)
 
 # Watson Discovery News Alerting
 
@@ -176,27 +175,6 @@ If the port is unavailable, you will see the following error:
 ```
 Error: listen EADDRINUSE :::{port}
 ```
-
-# Privacy Notice
-
-If using the Deploy to IBM Cloud button some metrics are tracked, the following information is sent to a [Deployment Tracker](https://github.com/IBM-IBM Cloud/cf-deployment-tracker-service) service
-on each deployment:
-
-* Node.js package version
-* Node.js repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`)
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-
-This data is collected from the `package.json` file in the sample application and the ``VCAP_APPLICATION`` and ``VCAP_SERVICES`` environment variables in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
-
-## Disabling Deployment Tracking
-Deployment tracking can be disabled by removing the `require("metrics-tracker-client").track();` line from [app/server.js](app/server.js#L29).
 
 # Links
 * [Demo on Youtube](https://youtu.be/zFl-2FybDdY): Watch the video.

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,6 @@
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.28.0",
     "jest": "20.0.3",
-    "metrics-tracker-client": "*",
     "morgan": "^1.8.2",
     "nodemailer": "^4.0.1",
     "object-assign": "4.1.1",

--- a/app/server.js
+++ b/app/server.js
@@ -26,8 +26,6 @@ import { track, subscriptionsByEmail, unsubscribe, updateDestination } from './s
 import { useCode } from './src/models/access'
 import { BRAND_ALERTS, PRODUCT_ALERTS, RELATED_BRANDS, POSITIVE_PRODUCT_ALERTS, STOCK_ALERTS } from './src/watson/constants'
 
-require('metrics-tracker-client').track();
-
 const app = express()
 const port = process.env.PORT || 4391
 


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
i.e. require('metrics-tracker-client').track();
requirement.txt or package.json for metrics-tracker