### PR TITLE
Use Node 7 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 6
+node_js: 7.10.0
 cache: yarn
 before_script:
   - cd app


### PR DESCRIPTION
We require Node 7.10.0 in package.json, so we need Node 7
to run Travis CI.
Otherwise, we get an error during `yarn install` due to the mismatch.