### PR TITLE
[chore] fix inconsistent component state updates

### DIFF
--- a/app/src/components/track.js
+++ b/app/src/components/track.js
@@ -109,9 +109,9 @@ class AlertExample extends Component {
   }
 
   onShowExampleAggregationResponse() {
-    this.setState({
-      showExampleAggregationResponse: !this.state.showExampleAggregationResponse
-    })
+    this.setState(prevState => ({
+      showExampleAggregationResponse: !prevState.showExampleAggregationResponse
+    }))
   }
 
   onExitExampleResultResponse() {
@@ -121,9 +121,9 @@ class AlertExample extends Component {
   }
 
   onShowExampleResultResponse() {
-    this.setState({
-      showExampleResultResponse: !this.state.showExampleResultResponse
-    })
+    this.setState(prevState => ({
+      showExampleResultResponse: !prevState.showExampleResultResponse
+    }))
   }
 
   // Sort each article returned by its date in the aggregation results, this is used to make the chart legible.


### PR DESCRIPTION
React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

These were all found on LGTM.com, and there are [a bunch of other alerts](https://lgtm.com/projects/g/IBM/watson-discovery-news-alerting/alerts) for this project that would probably also be good to fix.

*(Full disclosure: I'm part of the team behind LGTM.com)*